### PR TITLE
Fix _name_search returning tuples instead of IDs

### DIFF
--- a/union_affiliation/models/affiliate.py
+++ b/union_affiliation/models/affiliate.py
@@ -366,20 +366,18 @@ class Affiliate(models.Model):
         return False
 
     @api.model
-    def _name_search(self, name, args=None, operator='ilike', limit=100):
-        args = args or []
+    def _name_search(self, name='', args=None, operator='ilike', limit=100, name_get_uid=None):
+        """Extiende la búsqueda para que matchee personal_id, name o uid."""
+        args = list(args or [])
         if not name:
-            return super()._name_search(name, args, operator, limit)
+            return super()._name_search(name, args, operator, limit, name_get_uid)
 
-        domain = ['|', '|', 
+        domain = ['|', '|',
                 ('personal_id', operator, name),
-                ('name', operator, name), 
+                ('name', operator, name),
                 ('uid', operator, name)]
-        
-        recs = self.search(domain + args, limit=limit)
-        if not recs:
-            return []
-        return recs.name_get()
+
+        return self._search(domain + args, limit=limit, access_rights_uid=name_get_uid)
 
     def _message_get_suggested_recipients(self):
         recipients = super(Affiliate, self)._message_get_suggested_recipients()


### PR DESCRIPTION
## Summary
- `_name_search` on `affiliation.affiliate` was returning `recs.name_get()` (`[(id, name), ...]`) instead of a list of IDs
- This breaks filtering by affiliate in any list view that uses `affiliate_id` as a search field (SQL error: `operator does not exist: integer = record`)
- Fixed by returning `self._search(...)` which returns IDs as expected

## Test plan
- [ ] Open Cuentas de Pago > Resúmenes Económicos
- [ ] Search by affiliate name (e.g., "PEREZ") — should filter without errors
- [ ] Search by personal_id, by uid — both should work too

Closes #23