### PR TITLE
Fix affiliate_type translation import and remove malformed PO entry

### DIFF
--- a/union_affiliation/i18n/es_AR.po
+++ b/union_affiliation/i18n/es_AR.po
@@ -1298,7 +1298,3 @@ msgstr "Motivo de desafiliacion"
 msgid "Parents"
 msgstr "Padres"
 
-#. module: base
-#: model:res.partner,field:name
-msgid "Name"
-msgstr "Nombre completo"

--- a/union_affiliation/models/affiliate_type.py
+++ b/union_affiliation/models/affiliate_type.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from odoo import models, fields, api
+from odoo import models, fields, api, _
 from odoo.exceptions import ValidationError
 
 class AffiliateType(models.Model):


### PR DESCRIPTION
## Summary
Two related bugs that block module loading and constraint enforcement:

- **affiliate_type.py**: missing \`_\` import. The constraint \`_check_name\` raises \`ValidationError(_('...'))\` but \`_\` is not imported, so the constraint fails with \`NameError\` instead of the intended \`ValidationError\` (e.g. when importing duplicate \"Activo\" types, the user sees \"Error desconocido\" instead of the real cause).
- **es_AR.po**: invalid occurrence \`model:res.partner,field:name\` breaks module upgrade with \`ParseError: malformed po file: unknown occurrence\`.

## Test plan
- [ ] Try to import a duplicate affiliate_type — should see proper "There is already exist a type" error, not NameError
- [ ] Run module upgrade — should not fail with malformed po error

Closes #25