### PR TITLE
Allow upsert by natural key when importing affiliate types

### DIFF
--- a/union_affiliation/models/affiliate_type.py
+++ b/union_affiliation/models/affiliate_type.py
@@ -19,3 +19,63 @@ class AffiliateType(models.Model):
         other = self.search(filter)
         if len(other.ids):
             raise ValidationError(_('There is already exist a type with the same name!'))
+
+    @api.model
+    def load(self, fields, data):
+        """Override para hacer upsert por la clave natural ``name``.
+
+        Si una fila importada tiene un ``name`` que coincide con un registro
+        existente, se inyecta el External ID del existente para que Odoo
+        actualice (en vez de fallar contra el constraint de unicidad).
+        Las filas se reportan como warnings en el preview de "Probar".
+        """
+        if 'name' not in fields or 'id' in fields:
+            return super().load(fields, data)
+
+        name_idx = fields.index('name')
+        IMD = self.env['ir.model.data']
+        new_fields = ['id'] + list(fields)
+        new_data = []
+        warnings_msgs = []
+
+        for row_idx, row in enumerate(data, start=2):  # fila 1 = header
+            name = row[name_idx]
+            if not name:
+                new_data.append(['', *row])
+                continue
+
+            existing = self.search([('name', '=', name)], limit=1)
+            if not existing:
+                new_data.append(['', *row])
+                continue
+
+            imd = IMD.search([
+                ('model', '=', self._name),
+                ('res_id', '=', existing.id),
+            ], limit=1)
+            if imd:
+                xml_id = f"{imd.module}.{imd.name}"
+            else:
+                ext_name = f'affiliate_type_{existing.id}'
+                IMD.create({
+                    'module': '__import__',
+                    'name': ext_name,
+                    'model': self._name,
+                    'res_id': existing.id,
+                })
+                xml_id = f"__import__.{ext_name}"
+
+            new_data.append([xml_id, *row])
+            warnings_msgs.append({
+                'type': 'warning',
+                'message': _('Fila %(row)s: el tipo "%(name)s" ya existe — se actualizará en vez de crear uno nuevo.') % {
+                    'row': row_idx,
+                    'name': name,
+                },
+                'rows': {'from': row_idx - 1, 'to': row_idx - 1},
+            })
+
+        result = super().load(new_fields, new_data)
+        if warnings_msgs:
+            result.setdefault('messages', []).extend(warnings_msgs)
+        return result


### PR DESCRIPTION
## Qué

Override de `load()` en `affiliation.affiliate_type` para que la importación por nombre haga **upsert** en lugar de fallar.

## Por qué

El modelo tiene un constraint de unicidad por `name`. Al importar un archivo sin columna de External ID (`id`), Odoo trata cada fila como un registro nuevo y, si el `name` ya existe, la importación falla contra el constraint. Esto rompe el caso típico de re-importar o actualizar masivamente la lista de tipos.

## Cómo

- Si la fila trae un `name` que ya existe, se inyecta el External ID del registro existente (reutilizando `ir.model.data` o creando uno bajo `__import__`) para que Odoo ejecute un **UPDATE**.
- Las filas que se van a actualizar se reportan como *warnings* en el preview de "Probar".
- Si el archivo ya trae columna `id`, o no trae `name`, se delega al `load()` original sin cambios.

## Contexto

Replica el mismo patrón de upsert por clave natural ya mergeado para el historial de básicos (#81) y la importación de payment accounts (#76), aplicado ahora al catálogo de tipos de afiliado.