### PR TITLE
Fix affiliate name search crashing on text terms against integer uid

### DIFF
--- a/union_affiliation/models/affiliate.py
+++ b/union_affiliation/models/affiliate.py
@@ -390,10 +390,15 @@ class Affiliate(models.Model):
         if not name:
             return super()._name_search(name, args, operator, limit, name_get_uid)
 
-        domain = ['|', '|',
+        domain = ['|',
                 ('personal_id', operator, name),
-                ('name', operator, name),
-                ('uid', operator, name)]
+                ('name', operator, name)]
+        # uid es Integer: incluirlo solo con términos numéricos. Con texto,
+        # el ORM intenta int(name) y revienta — p. ej. al importar un M2O
+        # por nombre, que resuelve con operator '=' (no pasa con ilike
+        # porque castea la columna a texto).
+        if name.isdigit():
+            domain = ['|'] + domain + [('uid', operator, name)]
 
         return self._search(domain + args, limit=limit, access_rights_uid=name_get_uid)
 


### PR DESCRIPTION
## Qué

`_name_search` de `affiliation.affiliate` compara el término de búsqueda contra `uid` con el operador que venga, incondicionalmente. Como `uid` es Integer, cualquier término no numérico con operador de coincidencia exacta hace que el ORM intente `int(term)` y lance `ValueError`.

## Impacto

**Importar cualquier Many2one a afiliado por nombre estaba roto**: la importación resuelve con operador `=`, así que por ejemplo el import de resúmenes económicos (`affiliate.payment_account`) fallaba en TODAS las filas con:

```
invalid literal for int() with base 10: 'ALEJANDRO MIGUEL ZIELENIEWSKI'
```

El autocompletado de la UI no lo sufre porque usa `ilike`, que castea la columna a texto — por eso el bug pasó desapercibido hasta ahora.

## Fix

Incluir la comparación contra `uid` solo cuando el término es numérico. La búsqueda parcial por legajo en el autocompletado sigue funcionando via `ilike`.

## Verificación

Sobre una base con datos reales:
- `name_search('ALEJANDRO MIGUEL ZIELENIEWSKI', operator='=')` → antes `ValueError`, ahora 1 resultado.
- `name_search('522', operator='ilike')` → sigue matcheando legajos parcialmente.
- Import por interfaz de un xlsx de 242 resúmenes económicos resolviendo afiliado por nombre → "Todo parece válido".